### PR TITLE
Support SSO with other apps

### DIFF
--- a/00-Starter-Seed/README.md
+++ b/00-Starter-Seed/README.md
@@ -10,6 +10,8 @@ Before starting, make sure you have `composer` and `php` installed.
 
 Copy the `.env.example` file to `.env` and populate it with your app's Domain, Client ID, and Client Secret. These can be retrieved from your [Auth0 dashboard](https://manage.auth0.com).
 
+Populate auth_config.json with settings of your Auth0 SPA. This is need to implement seamless Single Sign On between this PHP application and other Auth0 apps.
+
 ## Running the App
 
 ```bash

--- a/00-Starter-Seed/auth_config.json
+++ b/00-Starter-Seed/auth_config.json
@@ -1,0 +1,4 @@
+{
+  "domain": "xxxx.auth0.com",
+  "clientId": "yyyy"
+}

--- a/00-Starter-Seed/index.php
+++ b/00-Starter-Seed/index.php
@@ -20,8 +20,12 @@ $userInfo = $auth0->getUser();
         <!-- font awesome from BootstrapCDN -->
         <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet">
         <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" rel="stylesheet">
-
         <link href="public/app.css" rel="stylesheet">
+        
+        <?php if(!$userInfo): ?>
+          <script src="https://cdn.auth0.com/js/auth0-spa-js/1.9/auth0-spa-js.production.js"></script>
+          <script src="public/sso.js"></script>
+        <?php endif ?>
 
     </head>
     <body class="home">

--- a/00-Starter-Seed/public/sso.js
+++ b/00-Starter-Seed/public/sso.js
@@ -1,0 +1,36 @@
+// The Auth0 client, initialized in configureClient()
+let auth0 = null;
+
+/**
+ * Retrieves the auth configuration from the server
+ */
+const fetchAuthConfig = () => fetch("/auth_config.json");
+
+/**
+ * Initializes the Auth0 client
+ */
+const configureClient = async () => {
+  const response = await fetchAuthConfig();
+  const config = await response.json();
+
+  auth0 = await createAuth0Client({
+    domain: config.domain,
+    client_id: config.clientId
+  });
+};
+
+// Will run when page finishes loading
+window.onload = async () => {
+  await configureClient();
+
+  const isAuthenticated = await auth0.isAuthenticated();
+
+  if (isAuthenticated) {
+    console.log("> User is authenticated");
+    //redirect to authentication page - user will be authenticated automatically
+    document.location.href = '/login.php' + document.location.search
+    return;
+  }
+
+  console.log("> User not authenticated");
+};


### PR DESCRIPTION
Added client side check for remote auth session. If session exists, user will be authenticated silently.

This solution needs client_id for Auth0 SSO app for client side checks, apparently it does not work with PHP app client_id