### PR TITLE
[SDK-2782] Update QS to use 8.0 BETA3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Auth0 Integration Samples for PHP Web Applications.",
   "require": {
     "php": "^8.0",
-    "auth0/auth0-php": "8.0.0-BETA1",
+    "auth0/auth0-php": "8.0.0-BETA3",
     "guzzlehttp/guzzle": "^7.3",
     "guzzlehttp/psr7": "^1.8",
     "http-interop/http-factory-guzzle": "^1.0",
@@ -27,16 +27,19 @@
   "prefer-stable": true,
   "scripts": {
     "app": [
+      "Composer\\Config::disableProcessTimeout",
       "@pre-run-app",
       "composer install --no-dev",
       "php -S 127.0.0.1:3000 public/index.php"
     ],
     "docker": [
+      "Composer\\Config::disableProcessTimeout",
       "@pre-run-app",
       "docker-compose run install",
       "docker-compose run --rm --service-ports quickstart"
     ],
     "tests": [
+      "Composer\\Config::disableProcessTimeout",
       "@pre-run-app",
       "docker-compose run --rm tests"
     ],

--- a/src/Example/PasswordlessMagic.php
+++ b/src/Example/PasswordlessMagic.php
@@ -59,7 +59,7 @@ final class PasswordlessMagic implements QuickstartExample
                 type: 'link',
                 params: [
                     'redirect_uri' => $router->getUri('/callback', ''),
-                    'scope' => $this->app->getConfiguration()->buildScopeString(),
+                    'scope' => $this->app->getConfiguration()->formatScope(),
                 ]
             );
 


### PR DESCRIPTION
This PR updates the v8 branch to use the new BETA3 release of 8.0. It also tweaks the Composer script commands to turn off process timeout, to avoid some longer-lived processes like the Docker container or built in web server from being terminated before desired.