### PR TITLE
Fix typo in docker-compose.yml

### DIFF
--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -21,7 +21,7 @@ services:
                    composer validate &&
                    composer install &&
                    php ./vendor/bin/phpinsights -v --no-interaction &&
-                   php ./vendor/bin/phpstan analyse --ansi --memory-limit 512M
+                   php ./vendor/bin/phpstan analyse --ansi --memory-limit 512M"
 
     install:
         image: composer:2.1


### PR DESCRIPTION
This PR addresses a typo in the docker-compose.yml file.

Resolves #77 